### PR TITLE
请求合入：忽略输出功能&代码改进&bug修复

### DIFF
--- a/src/EpubBuilder.cs
+++ b/src/EpubBuilder.cs
@@ -116,7 +116,7 @@ namespace UnpackKindleS
                 {
                     string p = "OEBPS/Text/" + xhtml_names[i];
                     string ss;
-                    var xmlSettings = new XmlWriterSettings { Indent = true, NewLineChars = "\n" };
+                    var xmlSettings = new XmlWriterSettings { Indent = true, NewLineChars = "\n", CheckCharacters = false };
                     using (var stringWriter = new StringWriter())
                     using (var xmlTextWriter = XmlWriter.Create(stringWriter, xmlSettings))
                     {
@@ -854,8 +854,10 @@ namespace UnpackKindleS
         {
             int htmlstart = xhtml.IndexOf("<html", 0, StringComparison.OrdinalIgnoreCase);
             xhtml = xhtml11doctype + xhtml.Substring(htmlstart);
+            string filt_xhtml = Util.EscapeInvalidXmlCharacters(xhtml);
+            if (filt_xhtml != xhtml) Log.log("[Warn] Invalid character found in xhtml, escaped.");
             XmlDocument d = new XmlDocument();
-            using (var rdr = new XmlTextReader(new StringReader(xhtml)))
+            using (var rdr = new XmlTextReader(new StringReader(filt_xhtml)))
             {
                 d.PreserveWhitespace = true;
                 rdr.DtdProcessing = DtdProcessing.Parse;

--- a/src/EpubBuilder.cs
+++ b/src/EpubBuilder.cs
@@ -338,7 +338,7 @@ namespace UnpackKindleS
                             string name = "embed" + Util.Number(resid) + font_Section.ext;
                             if (font_Section.ext == null)
                             {
-                                Log.log("[Warn] The referred font file is unrecognized: "+name);
+                                Log.log("[Warn] The referred font file is unrecognized: " + name);
                             }
                             link = "../Fonts/" + name;
                             font_Section.comment = name;
@@ -451,7 +451,7 @@ namespace UnpackKindleS
             CreateIndexDoc_Helper(root, temp_epub3, temp_epub2);
             //Create NAV
             {
-                string t = File.ReadAllText("template\\template_nav.txt");
+                string t = File.ReadAllText(Path.Combine(Environment.CurrentDirectory, "template", "template_nav.txt"));
                 t = t.Replace("{❕toc}", temp_epub3.ToString());
                 string guide = "";
                 if (azw3.guide_table != null)
@@ -475,7 +475,7 @@ namespace UnpackKindleS
                 nav = t;
             }
             {
-                string t = File.ReadAllText("template\\template_ncx.txt");
+                string t = File.ReadAllText(Path.Combine(Environment.CurrentDirectory, "template", "template_ncx.txt"));
 
                 t = t.Replace("{❕navMap}", temp_epub2.ToString());
                 t = t.Replace("{❕Title}", azw3.title);
@@ -501,7 +501,7 @@ namespace UnpackKindleS
                         {
                             Log.log("[Info]Adding a cover document.");
 
-                            string t = File.ReadAllText("template\\template_cover.txt");
+                            string t = File.ReadAllText(Path.Combine(Environment.CurrentDirectory, "template", "template_cover.txt"));
                             var (w, h) = Util.GetImageSize(imgs[img_names.IndexOf(cover_name)]);
                             cover = t.Replace("{❕image}", cover_name).Replace("{❕w}", w.ToString()).Replace("{❕h}", h.ToString());
 
@@ -535,7 +535,7 @@ namespace UnpackKindleS
         {
             if (azw3.resc != null)
             {
-                string t = File.ReadAllText("template\\template_opf.txt");
+                string t = File.ReadAllText(Path.Combine(Environment.CurrentDirectory, "template", "template_opf.txt"));
                 XmlDocument manifest = new XmlDocument();
                 XmlElement mani_root = manifest.CreateElement("manifest");
                 manifest.AppendChild(mani_root);

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -75,10 +75,10 @@ namespace UnpackKindleS
             if (!end_of_proc) ProcPath(args);
             if (append_log)
             {
-                Log.Append("..\\lastrun.log");
+                Log.Append(Path.Combine(Environment.CurrentDirectory, "..", "lastrun.log"));
             }
             else
-                Log.Save("..\\lastrun.log");
+                Log.Save(Path.Combine(Environment.CurrentDirectory, "..", "lastrun.log"));
 
             Environment.CurrentDirectory = temp_environment_dir;
         }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -14,6 +14,7 @@ namespace UnpackKindleS
         static bool append_log = false;
         static bool overwrite = false;
         static bool rename_when_exist = false;
+        static bool ignore_when_exist = false;
         static bool rename_xhtml_with_id = false;
         static void Main(string[] args)
         {
@@ -53,6 +54,10 @@ namespace UnpackKindleS
                 if (a.ToLower() == "--rename-when-exist")
                 {
                     rename_when_exist = true;
+                }
+                if (a.ToLower() == "--ignore-when-exist")
+                {
+                    ignore_when_exist = true;
                 }
                 if (a.ToLower() == "--rename-xhtml-with-id")
                 {
@@ -228,6 +233,11 @@ namespace UnpackKindleS
                         }
                         Log.log("[Warn]Save as...");
                     }
+                    else if (ignore_when_exist)
+                    {
+                        Log.log("[Warn]Output ignored.");
+                        output_path = "";
+                    }
                     else if (!overwrite)
                     {
                         Console.WriteLine("Output file already exist. N(Abort,Defualt)/y(Overwrite)/r(Rename)?");
@@ -256,7 +266,7 @@ namespace UnpackKindleS
                         }
                         else
                         {
-                            Log.log("[Error]Operation aborted. You can use --overwrite or --rename-when-exist to avoid pause.");
+                            Log.log("[Error]Operation aborted. You can use --overwrite or --rename-when-exist or --ignore-when-exist to avoid pause.");
                             output_path = "";
                         }
 

--- a/src/utils.cs
+++ b/src/utils.cs
@@ -172,6 +172,35 @@ namespace UnpackKindleS
             ;
         }
 
+        public static string EscapeInvalidXmlCharacters(string in_string)
+        {
+            // from https://stackoverflow.com/a/641632
+            if (in_string == null) return null;
+
+            StringBuilder str_buf = new StringBuilder();
+            char ch;
+
+            for (int i = 0; i < in_string.Length; i++)
+            {
+                ch = in_string[i];
+                if ((ch >= 0x0020 && ch <= 0xD7FF) ||
+                    (ch >= 0xE000 && ch <= 0xFFFD) ||
+                    ch == 0x0009 ||
+                    ch == 0x000A ||
+                    ch == 0x000D)
+                {
+                    str_buf.Append(ch);
+                }
+                else
+                {
+                    byte[] bytes = Encoding.UTF8.GetBytes(Char.ToString(ch));
+
+                    str_buf.Append("&#x" + Convert.ToHexString(bytes) + ";");
+                }
+            }
+            return str_buf.ToString();
+        }
+
         public static (int, int) GetImageSize(byte[] data)
         {
             using (var img = Image.FromStream(new MemoryStream(data)))


### PR DESCRIPTION
添加当epub文件存在时忽略输出的功能；
使用Path.Combine代替硬编码的路径，使代码跨平台可用；
自动过滤xhtml中的非UTF-8字符，避免epub转换失败。